### PR TITLE
fix: support parsing markdown with query strings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ function VitePluginMarkdown(userOptions: Options = {}): Plugin {
   const markdownToVue = createMarkdown(options)
 
   const filter = createFilter(
-    userOptions.include || /\.md$/,
+    userOptions.include || /\.md(\?.+)?$/,
     userOptions.exclude,
   )
 


### PR DESCRIPTION
## Description

context https://github.com/nuxt/nuxt/issues/20245

This adds out-of-the-box compatibility for Nuxt, which also needs to be able to parse markdown files with a query string.

