### PR TITLE
fix: shim require for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dev": "npm run build -- --watch",
     "example:dev": "cp README.md example/README.md && npm -C example run dev",
     "example:build": "cp README.md example/README.md && npm -C example run build",
-    "build": "tsup src/index.ts --dts --format cjs,esm",
+    "build": "tsup src/index.ts --dts --format cjs,esm --shims",
     "test": "vitest",
     "test:update": "vitest -u",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dev": "npm run build -- --watch",
     "example:dev": "cp README.md example/README.md && npm -C example run dev",
     "example:build": "cp README.md example/README.md && npm -C example run build",
-    "build": "tsup src/index.ts --dts --format cjs,esm --shims",
+    "build": "tsup src/index.ts --dts --format cjs,esm --shims --target=node12",
     "test": "vitest",
     "test:update": "vitest -u",
     "lint": "eslint .",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 export function getVueVersion(defaultVersion = '3.2.0') {
   try {
-    const _require = require
-    let v = _require('vue')
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    let v = require('vue')
     if (v.default)
       v = v.default
     return v.version || defaultVersion
@@ -13,8 +13,7 @@ export function getVueVersion(defaultVersion = '3.2.0') {
 
 export function isUnheadVueInstalled() {
   try {
-    const _require = require
-    _require('@unhead/vue')
+    require('@unhead/vue')
     return true
   }
   catch {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
 export function getVueVersion(defaultVersion = '3.2.0') {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     let v = require('vue')
     if (v.default)
       v = v.default

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,15 +1,8 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  banner(ctx) {
-    if (ctx.format === 'esm') {
-      return {
-        js: `
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-`.trim(),
-      }
-    }
+  esbuildOptions(options) {
+    options.supported ??= {}
+    options.supported['import-meta'] = true
   },
-  external: ['vue', '@unhead/vue'],
 })

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from 'tsup'
-
-export default defineConfig({
-  esbuildOptions(options) {
-    options.supported ??= {}
-    options.supported['import-meta'] = true
-  },
-})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  banner(ctx) {
+    if (ctx.format === 'esm') {
+      return {
+        js: `
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+`.trim(),
+      }
+    }
+  },
+  external: ['vue', '@unhead/vue'],
+})


### PR DESCRIPTION
Sorry, #18 wasn't working because `require` doesn't work in ESM.
This PR shim `require` for ESM.
